### PR TITLE
Update changed NGB links

### DIFF
--- a/src/components/ngb_config.js
+++ b/src/components/ngb_config.js
@@ -11,7 +11,7 @@ const NGB_CONFIG = [
     lat: -25.274399,
     long: 133.775131,
     imageSrc: 'https://iqasport.org/wp-content/uploads/2018/07/Australia_140.png',
-    url: 'http://www.quidditch.org.au/'
+    url: 'http://www.quidditchaustralia.org'
   },
   {
     name: 'Austria',
@@ -219,7 +219,7 @@ const NGB_CONFIG = [
     lat: 40.463669,
     long: -3.749220,
     imageSrc: 'https://iqasport.org/wp-content/uploads/2018/07/Spain_140.png',
-    url: 'https://www.facebook.com/AsociacionQuidditchEspana/'
+    url: 'https://www.aqe.es/'
   },
   {
     name: 'Sweden',

--- a/src/components/ngb_config.js
+++ b/src/components/ngb_config.js
@@ -4,7 +4,7 @@ const NGB_CONFIG = [
     lat: -38.416096,
     long: -63.616673,
     imageSrc: 'https://iqasport.org/wp-content/uploads/2018/07/Argentina_140.png',
-    url: 'https://www.facebook.com/asociaciondequidditch.arg/'
+    url: 'https://www.facebook.com/AQArg.Quidditch/'
   },
   {
     name: 'Australia',
@@ -18,7 +18,7 @@ const NGB_CONFIG = [
     lat: 47.516232,
     long: 14.550072,
     imageSrc: 'https://iqasport.org/wp-content/uploads/2018/07/Austria_140.png',
-    url: 'https://quidditch.at/en/'
+    url: 'https://quidditch.at/'
   },
   {
     name: 'Belgium',
@@ -191,7 +191,7 @@ const NGB_CONFIG = [
     lat: 35.907757,
     long: 127.766922,
     imageSrc: 'https://iqasport.org/wp-content/uploads/2018/07/Korea_140.png',
-    urls: 'https://www.facebook.com/quidditchkorea/'
+    url: 'https://www.facebook.com/quidditchkorea/'
   },
   {
     name: 'Serbia',
@@ -266,7 +266,7 @@ const NGB_CONFIG = [
   {
     name: 'Vietnam',
     imageSrc: 'https://iqasport.org/wp-content/uploads/2018/07/Vietnam_140.png',
-    url: ''
+    url: 'https://charity.quidditchvn.org/'
   }
 ]
 


### PR DESCRIPTION
This PR updates some NGB links for the world/logo map.

- Argentinia changed their facebook url
- Austria disbanded English site
- Vietnam had no url
- Korea had a typo